### PR TITLE
fix(lsp): set `timeout_ms` to `10000`

### DIFF
--- a/lua/universenvim/plugins/coding/lsp.lua
+++ b/lua/universenvim/plugins/coding/lsp.lua
@@ -54,7 +54,7 @@ return {
 			capabilities = {},
 			format = {
 				formatting_options = nil,
-				timeout_ms = nil,
+				timeout_ms = 10000,
 			},
 			servers = {
 				lua_ls = {


### PR DESCRIPTION
## Purpose

> Fix reiteratives warnings when formatting on save because of timeout

## Solution Approach

> Increase `LSP` format timeout