### PR TITLE
fix(cmp): added sorting function to prevent lsp snippets at top

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,10 +1,10 @@
 {
-	printWidth: 100,
-	semi: true,
-	singleQuote: true,
-	tabWidth: 2,
-	trailingComma: 'none',
-	bracketSpacing: true,
-	useTabs: false,
-	arrowParens: 'always'
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "useTabs": false,
+  "arrowParens": "always"
 }

--- a/lua/universenvim/config/autocommands.lua
+++ b/lua/universenvim/config/autocommands.lua
@@ -1,90 +1,90 @@
 local function augroup(name)
-  return vim.api.nvim_create_augroup("universenvim_" .. name, { clear = true })
+	return vim.api.nvim_create_augroup("universenvim_" .. name, { clear = true })
 end
 
 vim.api.nvim_create_autocmd({ "FocusGained", "TermClose", "TermLeave" }, {
-  group = augroup("checktime"),
-  callback = function()
-    if vim.o.buftype ~= 'nofile' then
-      vim.cmd('checktime')
-    end
-  end
+	group = augroup("checktime"),
+	callback = function()
+		if vim.o.buftype ~= "nofile" then
+			vim.cmd("checktime")
+		end
+	end,
 })
 
 vim.api.nvim_create_autocmd({ "VimResized" }, {
-  group = augroup("resize_splits"),
-  callback = function()
-    local current_tab = vim.fn.tabpagenr()
-    vim.cmd("tabdo wincmd =")
-    vim.cmd("tabnext " .. current_tab)
-  end,
+	group = augroup("resize_splits"),
+	callback = function()
+		local current_tab = vim.fn.tabpagenr()
+		vim.cmd("tabdo wincmd =")
+		vim.cmd("tabnext " .. current_tab)
+	end,
 })
 
 vim.api.nvim_create_autocmd("BufReadPost", {
-  group = augroup("last_loc"),
-  callback = function(event)
-    local exclude = { "gitcommit" }
-    local buf = event.buf
-    if vim.tbl_contains(exclude, vim.bo[buf].filetype) or vim.b[buf].universenvim_last_loc then
-      return
-    end
-    vim.b[buf].universenvim_last_loc = true
-    local mark = vim.api.nvim_buf_get_mark(buf, '"')
-    local lcount = vim.api.nvim_buf_line_count(buf)
-    if mark[1] > 0 and mark[1] <= lcount then
-      pcall(vim.api.nvim_win_set_cursor, 0, mark)
-    end
-  end,
+	group = augroup("last_loc"),
+	callback = function(event)
+		local exclude = { "gitcommit" }
+		local buf = event.buf
+		if vim.tbl_contains(exclude, vim.bo[buf].filetype) or vim.b[buf].universenvim_last_loc then
+			return
+		end
+		vim.b[buf].universenvim_last_loc = true
+		local mark = vim.api.nvim_buf_get_mark(buf, '"')
+		local lcount = vim.api.nvim_buf_line_count(buf)
+		if mark[1] > 0 and mark[1] <= lcount then
+			pcall(vim.api.nvim_win_set_cursor, 0, mark)
+		end
+	end,
 })
 
 vim.api.nvim_create_autocmd("FileType", {
-  group = augroup("close_with_q"),
-  pattern = {
-    "PlenaryTestPopup",
-    "help",
-    "lspinfo",
-    "man",
-    "notify",
-    "qf",
-    "query",
-    "spectre_panel",
-    "startuptime",
-    "tsplayground",
-    "neotest-output",
-    "checkhealth",
-    "neotest-summary",
-    "neotest-output-panel",
-  },
-  callback = function(event)
-    vim.bo[event.buf].buflisted = false
-    vim.keymap.set("n", "q", "<cmd>close<cr>", { buffer = event.buf, silent = true })
-  end,
+	group = augroup("close_with_q"),
+	pattern = {
+		"PlenaryTestPopup",
+		"help",
+		"lspinfo",
+		"man",
+		"notify",
+		"qf",
+		"query",
+		"spectre_panel",
+		"startuptime",
+		"tsplayground",
+		"neotest-output",
+		"checkhealth",
+		"neotest-summary",
+		"neotest-output-panel",
+	},
+	callback = function(event)
+		vim.bo[event.buf].buflisted = false
+		vim.keymap.set("n", "q", "<cmd>close<cr>", { buffer = event.buf, silent = true })
+	end,
 })
 
 vim.api.nvim_create_autocmd("FileType", {
-  group = augroup("wrap_spell"),
-  pattern = { "gitcommit", "markdown" },
-  callback = function()
-    vim.opt_local.wrap = true
-    vim.opt_local.spell = true
-  end,
+	group = augroup("wrap_spell"),
+	pattern = { "gitcommit", "markdown" },
+	callback = function()
+		vim.opt_local.wrap = true
+		vim.opt_local.spell = true
+	end,
 })
 
 vim.api.nvim_create_autocmd({ "FileType" }, {
-  group = augroup("json_conceal"),
-  pattern = { "json", "jsonc", "json5" },
-  callback = function()
-    vim.opt_local.conceallevel = 0
-  end,
+	group = augroup("json_conceal"),
+	pattern = { "json", "jsonc", "json5" },
+	callback = function()
+		vim.opt_local.conceallevel = 0
+	end,
 })
 
 vim.api.nvim_create_autocmd({ "BufWritePre" }, {
-  group = augroup("auto_create_dir"),
-  callback = function(event)
-    if event.match:match("^%w%w+://") then
-      return
-    end
-    local file = vim.loop.fs_realpath(event.match) or event.match
-    vim.fn.mkdir(vim.fn.fnamemodify(file, ":p:h"), "p")
-  end,
+	group = augroup("auto_create_dir"),
+	callback = function(event)
+		if event.match:match("^%w%w+://") then
+			return
+		end
+		local file = vim.loop.fs_realpath(event.match) or event.match
+		vim.fn.mkdir(vim.fn.fnamemodify(file, ":p:h"), "p")
+	end,
 })

--- a/lua/universenvim/config/init.lua
+++ b/lua/universenvim/config/init.lua
@@ -6,6 +6,6 @@ require("universenvim.config.autocommands")
 require("universenvim.config.keymaps")
 require("universenvim.config.options")
 
-local defaults = Utils.merge(constants, setup);
+local defaults = Utils.merge(constants, setup)
 
 return defaults

--- a/lua/universenvim/config/keymaps.lua
+++ b/lua/universenvim/config/keymaps.lua
@@ -87,10 +87,10 @@ keymap("x", "<A-k>", ":move '<-2<CR>gv-gv", opts)
 -- Telescope
 -- keymap("n", "<leader>f", "<cmd>Telescope find_files<cr>", opts)
 keymap(
-  "n",
-  "<c-p>",
-  "<cmd>lua require'telescope.builtin'.find_files(require('telescope.themes').get_dropdown({ previewer = false }))<cr>",
-  opts
+	"n",
+	"<c-p>",
+	"<cmd>lua require'telescope.builtin'.find_files(require('telescope.themes').get_dropdown({ previewer = false }))<cr>",
+	opts
 )
 keymap("n", "<c-t>", "<cmd>Telescope live_grep<cr>", opts)
 

--- a/lua/universenvim/config/options.lua
+++ b/lua/universenvim/config/options.lua
@@ -2,57 +2,57 @@ vim.g.autoformat = true
 vim.g.markdown_recommended_style = 0
 
 local options = {
-  autowrite = true,                        -- Enable auto write
-  backup = false,                          -- creates a backup file
-  clipboard = "unnamedplus",               -- allows neovim to access the system clipboard
-  cmdheight = 2,                           -- more space in the neovim command line for displaying messages
-  completeopt = "menu,menuone,noselect",   -- mostly just for cmp
-  conceallevel = 0,                        -- so that `` is visible in markdown files
-  fileencoding = "utf-8",                  -- the encoding written to a file
-  hlsearch = true,                         -- highlight all matches on previous search pattern
-  ignorecase = true,                       -- ignore case in search patterns
-  mouse = "a",                             -- allow the mouse to be used in neovim
-  pumheight = 10,                          -- pop up menu height
-  showmode = false,                        -- we don't need to see things like -- INSERT -- anymore
-  showtabline = 2,                         -- always show tabs
-  smartcase = true,                        -- smart case
-  smartindent = true,                      -- make indenting smarter again
-  splitbelow = true,                       -- force all horizontal splits to go below current window
-  splitright = true,                       -- force all vertical splits to go to the right of current window
-  swapfile = false,                        -- creates a swapfile
-  termguicolors = true,                    -- set term gui colors (most terminals support this)
-  timeoutlen = 100,                        -- time to wait for a mapped sequence to complete (in milliseconds)
-  undofile = true,                         -- enable persistent undo
-  updatetime = 300,                        -- faster completion (4000ms default)
-  writebackup = false,                     -- if a file is being edited by another program (or was written to file while editing with another program), it is not allowed to be edited
-  expandtab = true,                        -- convert tabs to spaces
-  shiftwidth = 2,                          -- the number of spaces inserted for each indentation
-  tabstop = 2,                             -- insert 2 spaces for a tab
-  cursorline = false,                      -- highlight the current line
-  number = true,                           -- set numbered lines
-  relativenumber = true,                   -- set relative numbered lines
-  numberwidth = 4,                         -- set number column width to 2 {default 4}
-  signcolumn = "yes",                      -- always show the sign column, otherwise it would shift the text each time
-  wrap = false,                            -- display lines as one long line
-  scrolloff = 8,                           -- is one of my fav
-  sidescrolloff = 8,
-  guifont = "monospace:h17",               -- the font used in graphical neovim applications
+	autowrite = true, -- Enable auto write
+	backup = false, -- creates a backup file
+	clipboard = "unnamedplus", -- allows neovim to access the system clipboard
+	cmdheight = 2, -- more space in the neovim command line for displaying messages
+	completeopt = "menu,menuone,noselect", -- mostly just for cmp
+	conceallevel = 0, -- so that `` is visible in markdown files
+	fileencoding = "utf-8", -- the encoding written to a file
+	hlsearch = true, -- highlight all matches on previous search pattern
+	ignorecase = true, -- ignore case in search patterns
+	mouse = "a", -- allow the mouse to be used in neovim
+	pumheight = 10, -- pop up menu height
+	showmode = false, -- we don't need to see things like -- INSERT -- anymore
+	showtabline = 2, -- always show tabs
+	smartcase = true, -- smart case
+	smartindent = true, -- make indenting smarter again
+	splitbelow = true, -- force all horizontal splits to go below current window
+	splitright = true, -- force all vertical splits to go to the right of current window
+	swapfile = false, -- creates a swapfile
+	termguicolors = true, -- set term gui colors (most terminals support this)
+	timeoutlen = 100, -- time to wait for a mapped sequence to complete (in milliseconds)
+	undofile = true, -- enable persistent undo
+	updatetime = 300, -- faster completion (4000ms default)
+	writebackup = false, -- if a file is being edited by another program (or was written to file while editing with another program), it is not allowed to be edited
+	expandtab = true, -- convert tabs to spaces
+	shiftwidth = 2, -- the number of spaces inserted for each indentation
+	tabstop = 2, -- insert 2 spaces for a tab
+	cursorline = false, -- highlight the current line
+	number = true, -- set numbered lines
+	relativenumber = true, -- set relative numbered lines
+	numberwidth = 4, -- set number column width to 2 {default 4}
+	signcolumn = "yes", -- always show the sign column, otherwise it would shift the text each time
+	wrap = false, -- display lines as one long line
+	scrolloff = 8, -- is one of my fav
+	sidescrolloff = 8,
+	guifont = "monospace:h17", -- the font used in graphical neovim applications
 }
 
-vim.opt.shortmess:append "c"
+vim.opt.shortmess:append("c")
 
 if vim.fn.has("nvim-0.10") == 1 then
-  vim.opt.smoothscroll = true
-  vim.opt.foldmethod = "expr"
+	vim.opt.smoothscroll = true
+	vim.opt.foldmethod = "expr"
 else
-  vim.opt.foldmethod = "indent"
+	vim.opt.foldmethod = "indent"
 end
 
 for k, v in pairs(options) do
-  vim.opt[k] = v
+	vim.opt[k] = v
 end
 
-vim.cmd "set whichwrap+=<,>,[,],h,l"
-vim.cmd[[autocmd FileType * setlocal formatoptions-=cro]]
+vim.cmd("set whichwrap+=<,>,[,],h,l")
+vim.cmd([[autocmd FileType * setlocal formatoptions-=cro]])
 
 vim.loader.enable()

--- a/lua/universenvim/plugins/coding/comment.lua
+++ b/lua/universenvim/plugins/coding/comment.lua
@@ -1,30 +1,29 @@
 return {
-  'numToStr/Comment.nvim',
-  lazy = false,
-  config = function()
-    local status_ok, comment = pcall(require, "Comment")
-    if not status_ok then
-      vim.notify("Comment could not be loaded!", "error")
-      return
-    end
+	"numToStr/Comment.nvim",
+	lazy = false,
+	config = function()
+		local status_ok, comment = pcall(require, "Comment")
+		if not status_ok then
+			vim.notify("Comment could not be loaded!", "error")
+			return
+		end
 
-    comment.setup({
-      pre_hook = function(ctx)
-        local U = require("Comment.utils")
+		comment.setup({
+			pre_hook = function(ctx)
+				local U = require("Comment.utils")
 
-        local location = nil
-        if ctx.ctype == U.ctype.block then
-          location = require("ts_context_commentstring.utils").get_cursor_location()
-        elseif ctx.cmotion == U.cmotion.v or ctx.cmotion == U.cmotion.V then
-          location = require("ts_context_commentstring.utils").get_visual_start_location()
-        end
+				local location = nil
+				if ctx.ctype == U.ctype.block then
+					location = require("ts_context_commentstring.utils").get_cursor_location()
+				elseif ctx.cmotion == U.cmotion.v or ctx.cmotion == U.cmotion.V then
+					location = require("ts_context_commentstring.utils").get_visual_start_location()
+				end
 
-        return require("ts_context_commentstring.internal").calculate_commentstring({
-          key = ctx.ctype == U.ctype.line and "__default" or "__multiline",
-          location = location,
-        })
-      end,
-    })
-  end
+				return require("ts_context_commentstring.internal").calculate_commentstring({
+					key = ctx.ctype == U.ctype.line and "__default" or "__multiline",
+					location = location,
+				})
+			end,
+		})
+	end,
 }
-

--- a/lua/universenvim/plugins/coding/dap.lua
+++ b/lua/universenvim/plugins/coding/dap.lua
@@ -1,128 +1,243 @@
 local function get_args(config)
-  local args = type(config.args) == "function" and (config.args() or {}) or config.args or {}
-  config = vim.deepcopy(config)
-  config.args = function()
-    local new_args = vim.fn.input("Run with args: ", table.concat(args, " "))
-    return vim.split(vim.fn.expand(new_args), " ")
-  end
-  return config
+	local args = type(config.args) == "function" and (config.args() or {}) or config.args or {}
+	config = vim.deepcopy(config)
+	config.args = function()
+		local new_args = vim.fn.input("Run with args: ", table.concat(args, " "))
+		return vim.split(vim.fn.expand(new_args), " ")
+	end
+	return config
 end
 
 return {
-  "mfussenegger/nvim-dap",
-  dependencies = {
-    {
-      "rcarriga/nvim-dap-ui",
-      keys = {
-        { "<leader>du", function() require("dapui").toggle({ }) end, desc = "Dap UI" },
-        { "<leader>de", function() require("dapui").eval() end, desc = "Eval", mode = {"n", "v"} },
-      },
-      opts = {},
-      config = function(_, opts)
-        local dap = require("dap")
-        local dapui = require("dapui")
-        dapui.setup(opts)
-        dap.listeners.after.event_initialized["dapui_config"] = function()
-          dapui.open({})
-        end
-        dap.listeners.before.event_terminated["dapui_config"] = function()
-          dapui.close({})
-        end
-        dap.listeners.before.event_exited["dapui_config"] = function()
-          dapui.close({})
-        end
-      end,
-    },
-    {
-      "theHamsta/nvim-dap-virtual-text",
-      opts = {},
-    },
-    {
-      "folke/which-key.nvim",
-      optional = true,
-      opts = {
-        defaults = {
-          ["<leader>d"] = { name = "+debug" },
-        },
-      },
-    },
-    {
-      "jay-babu/mason-nvim-dap.nvim",
-      dependencies = "mason.nvim",
-      cmd = { "DapInstall", "DapUninstall" },
-      opts = {
-        automatic_installation = true,
-        handlers = {},
-        ensure_installed = {},
-      },
-    },
-    {
-      "jbyuki/one-small-step-for-vimkind",
-      config = function()
-        local dap = require("dap")
-        dap.adapters.nlua = function(callback, conf)
-          local adapter = {
-            type = "server",
-            host = conf.host or "127.0.0.1",
-            port = conf.port or 8086,
-          }
-          if conf.start_neovim then
-            local dap_run = dap.run
-            dap.run = function(c)
-              adapter.port = c.port
-              adapter.host = c.host
-            end
-            require("osv").run_this()
-            dap.run = dap_run
-          end
-          callback(adapter)
-        end
-        dap.configurations.lua = {
-          {
-            type = "nlua",
-            request = "attach",
-            name = "Run this file",
-            start_neovim = {},
-          },
-          {
-            type = "nlua",
-            request = "attach",
-            name = "Attach to running Neovim instance (port = 8086)",
-            port = 8086,
-          },
-        }
-      end,
-    },
-  },
-  keys = {
-    { "<leader>dB", function() require("dap").set_breakpoint(vim.fn.input('Breakpoint condition: ')) end, desc = "Breakpoint Condition" },
-    { "<leader>db", function() require("dap").toggle_breakpoint() end, desc = "Toggle Breakpoint" },
-    { "<leader>dc", function() require("dap").continue() end, desc = "Continue" },
-    { "<leader>da", function() require("dap").continue({ before = get_args }) end, desc = "Run with Args" },
-    { "<leader>dC", function() require("dap").run_to_cursor() end, desc = "Run to Cursor" },
-    { "<leader>dg", function() require("dap").goto_() end, desc = "Go to line (no execute)" },
-    { "<leader>di", function() require("dap").step_into() end, desc = "Step Into" },
-    { "<leader>dj", function() require("dap").down() end, desc = "Down" },
-    { "<leader>dk", function() require("dap").up() end, desc = "Up" },
-    { "<leader>dl", function() require("dap").run_last() end, desc = "Run Last" },
-    { "<leader>do", function() require("dap").step_out() end, desc = "Step Out" },
-    { "<leader>dO", function() require("dap").step_over() end, desc = "Step Over" },
-    { "<leader>dp", function() require("dap").pause() end, desc = "Pause" },
-    { "<leader>dr", function() require("dap").repl.toggle() end, desc = "Toggle REPL" },
-    { "<leader>ds", function() require("dap").session() end, desc = "Session" },
-    { "<leader>dt", function() require("dap").terminate() end, desc = "Terminate" },
-    { "<leader>dw", function() require("dap.ui.widgets").hover() end, desc = "Widgets" },
-  },
-  config = function()
-    local Config = require("universenvim.config")
-    vim.api.nvim_set_hl(0, "DapStoppedLine", { default = true, link = "Visual" })
+	"mfussenegger/nvim-dap",
+	dependencies = {
+		{
+			"rcarriga/nvim-dap-ui",
+			keys = {
+				{
+					"<leader>du",
+					function()
+						require("dapui").toggle({})
+					end,
+					desc = "Dap UI",
+				},
+				{
+					"<leader>de",
+					function()
+						require("dapui").eval()
+					end,
+					desc = "Eval",
+					mode = { "n", "v" },
+				},
+			},
+			opts = {},
+			config = function(_, opts)
+				local dap = require("dap")
+				local dapui = require("dapui")
+				dapui.setup(opts)
+				dap.listeners.after.event_initialized["dapui_config"] = function()
+					dapui.open({})
+				end
+				dap.listeners.before.event_terminated["dapui_config"] = function()
+					dapui.close({})
+				end
+				dap.listeners.before.event_exited["dapui_config"] = function()
+					dapui.close({})
+				end
+			end,
+		},
+		{
+			"theHamsta/nvim-dap-virtual-text",
+			opts = {},
+		},
+		{
+			"folke/which-key.nvim",
+			optional = true,
+			opts = {
+				defaults = {
+					["<leader>d"] = { name = "+debug" },
+				},
+			},
+		},
+		{
+			"jay-babu/mason-nvim-dap.nvim",
+			dependencies = "mason.nvim",
+			cmd = { "DapInstall", "DapUninstall" },
+			opts = {
+				automatic_installation = true,
+				handlers = {},
+				ensure_installed = {},
+			},
+		},
+		{
+			"jbyuki/one-small-step-for-vimkind",
+			config = function()
+				local dap = require("dap")
+				dap.adapters.nlua = function(callback, conf)
+					local adapter = {
+						type = "server",
+						host = conf.host or "127.0.0.1",
+						port = conf.port or 8086,
+					}
+					if conf.start_neovim then
+						local dap_run = dap.run
+						dap.run = function(c)
+							adapter.port = c.port
+							adapter.host = c.host
+						end
+						require("osv").run_this()
+						dap.run = dap_run
+					end
+					callback(adapter)
+				end
+				dap.configurations.lua = {
+					{
+						type = "nlua",
+						request = "attach",
+						name = "Run this file",
+						start_neovim = {},
+					},
+					{
+						type = "nlua",
+						request = "attach",
+						name = "Attach to running Neovim instance (port = 8086)",
+						port = 8086,
+					},
+				}
+			end,
+		},
+	},
+	keys = {
+		{
+			"<leader>dB",
+			function()
+				require("dap").set_breakpoint(vim.fn.input("Breakpoint condition: "))
+			end,
+			desc = "Breakpoint Condition",
+		},
+		{
+			"<leader>db",
+			function()
+				require("dap").toggle_breakpoint()
+			end,
+			desc = "Toggle Breakpoint",
+		},
+		{
+			"<leader>dc",
+			function()
+				require("dap").continue()
+			end,
+			desc = "Continue",
+		},
+		{
+			"<leader>da",
+			function()
+				require("dap").continue({ before = get_args })
+			end,
+			desc = "Run with Args",
+		},
+		{
+			"<leader>dC",
+			function()
+				require("dap").run_to_cursor()
+			end,
+			desc = "Run to Cursor",
+		},
+		{
+			"<leader>dg",
+			function()
+				require("dap").goto_()
+			end,
+			desc = "Go to line (no execute)",
+		},
+		{
+			"<leader>di",
+			function()
+				require("dap").step_into()
+			end,
+			desc = "Step Into",
+		},
+		{
+			"<leader>dj",
+			function()
+				require("dap").down()
+			end,
+			desc = "Down",
+		},
+		{
+			"<leader>dk",
+			function()
+				require("dap").up()
+			end,
+			desc = "Up",
+		},
+		{
+			"<leader>dl",
+			function()
+				require("dap").run_last()
+			end,
+			desc = "Run Last",
+		},
+		{
+			"<leader>do",
+			function()
+				require("dap").step_out()
+			end,
+			desc = "Step Out",
+		},
+		{
+			"<leader>dO",
+			function()
+				require("dap").step_over()
+			end,
+			desc = "Step Over",
+		},
+		{
+			"<leader>dp",
+			function()
+				require("dap").pause()
+			end,
+			desc = "Pause",
+		},
+		{
+			"<leader>dr",
+			function()
+				require("dap").repl.toggle()
+			end,
+			desc = "Toggle REPL",
+		},
+		{
+			"<leader>ds",
+			function()
+				require("dap").session()
+			end,
+			desc = "Session",
+		},
+		{
+			"<leader>dt",
+			function()
+				require("dap").terminate()
+			end,
+			desc = "Terminate",
+		},
+		{
+			"<leader>dw",
+			function()
+				require("dap.ui.widgets").hover()
+			end,
+			desc = "Widgets",
+		},
+	},
+	config = function()
+		local Config = require("universenvim.config")
+		vim.api.nvim_set_hl(0, "DapStoppedLine", { default = true, link = "Visual" })
 
-    for name, sign in pairs(Config.icons.dap) do
-      sign = type(sign) == "table" and sign or { sign }
-      vim.fn.sign_define(
-        "Dap" .. name,
-        { text = sign[1], texthl = sign[2] or "DiagnosticInfo", linehl = sign[3], numhl = sign[3] }
-      )
-    end
-  end,
+		for name, sign in pairs(Config.icons.dap) do
+			sign = type(sign) == "table" and sign or { sign }
+			vim.fn.sign_define(
+				"Dap" .. name,
+				{ text = sign[1], texthl = sign[2] or "DiagnosticInfo", linehl = sign[3], numhl = sign[3] }
+			)
+		end
+	end,
 }

--- a/lua/universenvim/plugins/coding/flutter.lua
+++ b/lua/universenvim/plugins/coding/flutter.lua
@@ -1,9 +1,9 @@
 return {
-    'akinsho/flutter-tools.nvim',
-    lazy = false,
-    dependencies = {
-        'nvim-lua/plenary.nvim',
-        'stevearc/dressing.nvim', -- optional for vim.ui.select
-    },
-    config = true,
+	"akinsho/flutter-tools.nvim",
+	lazy = false,
+	dependencies = {
+		"nvim-lua/plenary.nvim",
+		"stevearc/dressing.nvim", -- optional for vim.ui.select
+	},
+	config = true,
 }

--- a/lua/universenvim/plugins/coding/markdown-preview.lua
+++ b/lua/universenvim/plugins/coding/markdown-preview.lua
@@ -1,6 +1,8 @@
 return {
-  "iamcco/markdown-preview.nvim",
-  cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
-  ft = { "markdown" },
-  build = function() vim.fn["mkdp#util#install"]() end
-} 
+	"iamcco/markdown-preview.nvim",
+	cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
+	ft = { "markdown" },
+	build = function()
+		vim.fn["mkdp#util#install"]()
+	end,
+}

--- a/lua/universenvim/plugins/editor/cmp.lua
+++ b/lua/universenvim/plugins/editor/cmp.lua
@@ -14,6 +14,7 @@ return {
 		opts = function()
 			vim.api.nvim_set_hl(0, "CmpGhostText", { link = "Comment", default = true })
 			local cmp = require("cmp")
+			local types = require("cmp.types")
 			local defaults = require("cmp.config.default")()
 			local kind_icons = {
 				Array = " ",
@@ -56,6 +57,21 @@ return {
 				Value = " ",
 				Variable = "󰀫 ",
 			}
+
+			local function deprioritize_snippet(entry1, entry2)
+				if entry1:get_kind() == types.lsp.CompletionItemKind.Snippet then
+					return false
+				end
+				if entry2:get_kind() == types.lsp.CompletionItemKind.Snippet then
+					return true
+				end
+			end
+
+			local comparators = { deprioritize_snippet }
+
+			for _, default_comparator in ipairs(defaults.sorting.comparators) do
+				table.insert(comparators, default_comparator)
+			end
 
 			return {
 				completion = {
@@ -122,7 +138,10 @@ return {
 						hl_group = "CmpGhostText",
 					},
 				},
-				sorting = defaults.sorting,
+				sorting = {
+					priority_weigth = 2,
+					comparators = comparators,
+				},
 			}
 		end,
 		config = function(_, opts)

--- a/lua/universenvim/plugins/editor/neogen.lua
+++ b/lua/universenvim/plugins/editor/neogen.lua
@@ -1,8 +1,7 @@
 return {
-  "danymat/neogen",
-  config = function()
-    require("neogen").setup({})
-  end,
-  dependencies = "nvim-treesitter/nvim-treesitter",
+	"danymat/neogen",
+	config = function()
+		require("neogen").setup({})
+	end,
+	dependencies = "nvim-treesitter/nvim-treesitter",
 }
-

--- a/lua/universenvim/plugins/langs/clangd.lua
+++ b/lua/universenvim/plugins/langs/clangd.lua
@@ -1,146 +1,149 @@
 local Utils = require("universenvim.utils")
 
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "c", "cpp" })
-      end
-    end,
-  },
-  {
-    "p00f/clangd_extensions.nvim",
-    lazy = true,
-    config = function() end,
-    opts = {
-      inlay_hints = {
-        inline = false,
-      },
-      ast = {
-        role_icons = {
-          type = "",
-          declaration = "",
-          expression = "",
-          specifier = "",
-          statement = "",
-          ["template argument"] = "",
-        },
-        kind_icons = {
-          Compound = "",
-          Recovery = "",
-          TranslationUnit = "",
-          PackExpansion = "",
-          TemplateTypeParm = "",
-          TemplateTemplateParm = "",
-          TemplateParamObject = "",
-        },
-      },
-    },
-  },
-  {
-    "neovim/nvim-lspconfig",
-    opts = {
-      servers = {
-        clangd = {
-          keys = {
-            { "<leader>cR", "<cmd>ClangdSwitchSourceHeader<cr>", desc = "Switch Source/Header (C/C++)" },
-          },
-          root_dir = function(fname)
-            return require("lspconfig.util").root_pattern(
-              "Makefile",
-              "configure.ac",
-              "configure.in",
-              "config.h.in",
-              "meson.build",
-              "meson_options.txt",
-              "build.ninja"
-            )(fname) or require("lspconfig.util").root_pattern("compile_commands.json", "compile_flags.txt")(
-              fname
-            ) or require("lspconfig.util").find_git_ancestor(fname)
-          end,
-          capabilities = {
-            offsetEncoding = { "utf-16" },
-          },
-          cmd = {
-            "clangd",
-            "--background-index",
-            "--clang-tidy",
-            "--header-insertion=iwyu",
-            "--completion-style=detailed",
-            "--function-arg-placeholders",
-            "--fallback-style=llvm",
-          },
-          init_options = {
-            usePlaceholders = true,
-            completeUnimported = true,
-            clangdFileStatus = true,
-          },
-        },
-      },
-      setup = {
-        clangd = function(_, opts)
-          local clangd_ext_opts = Utils.opts("clangd_extensions.nvim")
-          require("clangd_extensions").setup(vim.tbl_deep_extend("force", clangd_ext_opts or {}, { server = opts }))
-          return false
-        end,
-      },
-    },
-  },
-  {
-    "nvim-cmp",
-    opts = function(_, opts)
-      table.insert(opts.sorting.comparators, 1, require("clangd_extensions.cmp_scores"))
-    end,
-  },
-  {
-    "mfussenegger/nvim-dap",
-    optional = true,
-    dependencies = {
-      "williamboman/mason.nvim",
-      optional = true,
-      opts = function(_, opts)
-        if type(opts.ensure_installed) == "table" then
-          vim.list_extend(opts.ensure_installed, { "codelldb" })
-        end
-      end,
-    },
-    opts = function()
-      local dap = require("dap")
-      if not dap.adapters["codelldb"] then
-        require("dap").adapters["codelldb"] = {
-          type = "server",
-          host = "localhost",
-          port = "${port}",
-          executable = {
-            command = "codelldb",
-            args = {
-              "--port",
-              "${port}",
-            },
-          },
-        }
-      end
-      for _, lang in ipairs({ "c", "cpp" }) do
-        dap.configurations[lang] = {
-          {
-            type = "codelldb",
-            request = "launch",
-            name = "Launch file",
-            program = function()
-              return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
-            end,
-            cwd = "${workspaceFolder}",
-          },
-          {
-            type = "codelldb",
-            request = "attach",
-            name = "Attach to process",
-            processId = require("dap.utils").pick_process,
-            cwd = "${workspaceFolder}",
-          },
-        }
-      end
-    end,
-  },
+	{
+		"nvim-treesitter/nvim-treesitter",
+		opts = function(_, opts)
+			if type(opts.ensure_installed) == "table" then
+				vim.list_extend(opts.ensure_installed, { "c", "cpp" })
+			end
+		end,
+	},
+	{
+		"p00f/clangd_extensions.nvim",
+		lazy = true,
+		config = function() end,
+		opts = {
+			inlay_hints = {
+				inline = false,
+			},
+			ast = {
+				role_icons = {
+					type = "",
+					declaration = "",
+					expression = "",
+					specifier = "",
+					statement = "",
+					["template argument"] = "",
+				},
+				kind_icons = {
+					Compound = "",
+					Recovery = "",
+					TranslationUnit = "",
+					PackExpansion = "",
+					TemplateTypeParm = "",
+					TemplateTemplateParm = "",
+					TemplateParamObject = "",
+				},
+			},
+		},
+	},
+	{
+		"neovim/nvim-lspconfig",
+		opts = {
+			servers = {
+				clangd = {
+					keys = {
+						{ "<leader>cR", "<cmd>ClangdSwitchSourceHeader<cr>", desc = "Switch Source/Header (C/C++)" },
+					},
+					root_dir = function(fname)
+						return require("lspconfig.util").root_pattern(
+							"Makefile",
+							"configure.ac",
+							"configure.in",
+							"config.h.in",
+							"meson.build",
+							"meson_options.txt",
+							"build.ninja"
+						)(fname) or require("lspconfig.util").root_pattern(
+							"compile_commands.json",
+							"compile_flags.txt"
+						)(fname) or require("lspconfig.util").find_git_ancestor(fname)
+					end,
+					capabilities = {
+						offsetEncoding = { "utf-16" },
+					},
+					cmd = {
+						"clangd",
+						"--background-index",
+						"--clang-tidy",
+						"--header-insertion=iwyu",
+						"--completion-style=detailed",
+						"--function-arg-placeholders",
+						"--fallback-style=llvm",
+					},
+					init_options = {
+						usePlaceholders = true,
+						completeUnimported = true,
+						clangdFileStatus = true,
+					},
+				},
+			},
+			setup = {
+				clangd = function(_, opts)
+					local clangd_ext_opts = Utils.opts("clangd_extensions.nvim")
+					require("clangd_extensions").setup(
+						vim.tbl_deep_extend("force", clangd_ext_opts or {}, { server = opts })
+					)
+					return false
+				end,
+			},
+		},
+	},
+	{
+		"nvim-cmp",
+		opts = function(_, opts)
+			table.insert(opts.sorting.comparators, 1, require("clangd_extensions.cmp_scores"))
+		end,
+	},
+	{
+		"mfussenegger/nvim-dap",
+		optional = true,
+		dependencies = {
+			"williamboman/mason.nvim",
+			optional = true,
+			opts = function(_, opts)
+				if type(opts.ensure_installed) == "table" then
+					vim.list_extend(opts.ensure_installed, { "codelldb" })
+				end
+			end,
+		},
+		opts = function()
+			local dap = require("dap")
+			if not dap.adapters["codelldb"] then
+				require("dap").adapters["codelldb"] = {
+					type = "server",
+					host = "localhost",
+					port = "${port}",
+					executable = {
+						command = "codelldb",
+						args = {
+							"--port",
+							"${port}",
+						},
+					},
+				}
+			end
+			for _, lang in ipairs({ "c", "cpp" }) do
+				dap.configurations[lang] = {
+					{
+						type = "codelldb",
+						request = "launch",
+						name = "Launch file",
+						program = function()
+							return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+						end,
+						cwd = "${workspaceFolder}",
+					},
+					{
+						type = "codelldb",
+						request = "attach",
+						name = "Attach to process",
+						processId = require("dap.utils").pick_process,
+						cwd = "${workspaceFolder}",
+					},
+				}
+			end
+		end,
+	},
 }

--- a/lua/universenvim/plugins/langs/docker.lua
+++ b/lua/universenvim/plugins/langs/docker.lua
@@ -1,45 +1,45 @@
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "dockerfile" })
-      end
-    end,
-  },
-  {
-    "mason.nvim",
-    opts = function(_, opts)
-      opts.ensure_installed = opts.ensure_installed or {}
-      vim.list_extend(opts.ensure_installed, { "hadolint" })
-    end,
-  },
-  {
-    "nvimtools/none-ls.nvim",
-    optional = true,
-    opts = function(_, opts)
-      local nls = require("null-ls")
-      opts.sources = vim.list_extend(opts.sources or {}, {
-        nls.builtins.diagnostics.hadolint,
-      })
-    end,
-  },
-  {
-    "mfussenegger/nvim-lint",
-    optional = true,
-    opts = {
-      linters_by_ft = {
-        dockerfile = { "hadolint" },
-      },
-    },
-  },
-  {
-    "neovim/nvim-lspconfig",
-    opts = {
-      servers = {
-        dockerls = {},
-        docker_compose_language_service = {},
-      },
-    },
-  },
+	{
+		"nvim-treesitter/nvim-treesitter",
+		opts = function(_, opts)
+			if type(opts.ensure_installed) == "table" then
+				vim.list_extend(opts.ensure_installed, { "dockerfile" })
+			end
+		end,
+	},
+	{
+		"mason.nvim",
+		opts = function(_, opts)
+			opts.ensure_installed = opts.ensure_installed or {}
+			vim.list_extend(opts.ensure_installed, { "hadolint" })
+		end,
+	},
+	{
+		"nvimtools/none-ls.nvim",
+		optional = true,
+		opts = function(_, opts)
+			local nls = require("null-ls")
+			opts.sources = vim.list_extend(opts.sources or {}, {
+				nls.builtins.diagnostics.hadolint,
+			})
+		end,
+	},
+	{
+		"mfussenegger/nvim-lint",
+		optional = true,
+		opts = {
+			linters_by_ft = {
+				dockerfile = { "hadolint" },
+			},
+		},
+	},
+	{
+		"neovim/nvim-lspconfig",
+		opts = {
+			servers = {
+				dockerls = {},
+				docker_compose_language_service = {},
+			},
+		},
+	},
 }

--- a/lua/universenvim/plugins/langs/go.lua
+++ b/lua/universenvim/plugins/langs/go.lua
@@ -1,154 +1,154 @@
 local Utils = require("universenvim.utils")
 
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, {
-          "go",
-          "gomod",
-          "gowork",
-          "gosum",
-        })
-      end
-    end,
-  },
-  {
-    "neovim/nvim-lspconfig",
-    opts = {
-      servers = {
-        gopls = {
-          keys = {
-            -- Workaround for the lack of a DAP strategy in neotest-go: https://github.com/nvim-neotest/neotest-go/issues/12
-            { "<leader>td", "<cmd>lua require('dap-go').debug_test()<CR>", desc = "Debug Nearest (Go)" },
-          },
-          settings = {
-            gopls = {
-              gofumpt = true,
-              codelenses = {
-                gc_details = false,
-                generate = true,
-                regenerate_cgo = true,
-                run_govulncheck = true,
-                test = true,
-                tidy = true,
-                upgrade_dependency = true,
-                vendor = true,
-              },
-              hints = {
-                assignVariableTypes = true,
-                compositeLiteralFields = true,
-                compositeLiteralTypes = true,
-                constantValues = true,
-                functionTypeParameters = true,
-                parameterNames = true,
-                rangeVariableTypes = true,
-              },
-              analyses = {
-                fieldalignment = true,
-                nilness = true,
-                unusedparams = true,
-                unusedwrite = true,
-                useany = true,
-              },
-              usePlaceholders = true,
-              completeUnimported = true,
-              staticcheck = true,
-              directoryFilters = { "-.git", "-.vscode", "-.idea", "-.vscode-test", "-node_modules" },
-              semanticTokens = true,
-            },
-          },
-        },
-      },
-      setup = {
-        gopls = function()
-          -- workaround for gopls not supporting semanticTokensProvider
-          -- https://github.com/golang/go/issues/54531#issuecomment-1464982242
-          Utils.lsp.on_attach(function(client, _)
-            if client.name == "gopls" then
-              if not client.server_capabilities.semanticTokensProvider then
-                local semantic = client.config.capabilities.textDocument.semanticTokens
-                client.server_capabilities.semanticTokensProvider = {
-                  full = true,
-                  legend = {
-                    tokenTypes = semantic.tokenTypes,
-                    tokenModifiers = semantic.tokenModifiers,
-                  },
-                  range = true,
-                }
-              end
-            end
-          end)
-        end,
-      },
-    },
-  },
-  {
-    "williamboman/mason.nvim",
-    opts = function(_, opts)
-      opts.ensure_installed = opts.ensure_installed or {}
-      vim.list_extend(opts.ensure_installed, { "goimports", "gofumpt" })
-    end,
-  },
-  {
-    "nvimtools/none-ls.nvim",
-    optional = true,
-    dependencies = {
-      {
-        "williamboman/mason.nvim",
-        opts = function(_, opts)
-          opts.ensure_installed = opts.ensure_installed or {}
-          vim.list_extend(opts.ensure_installed, { "gomodifytags", "impl" })
-        end,
-      },
-    },
-    opts = function(_, opts)
-      local nls = require("null-ls")
-      opts.sources = vim.list_extend(opts.sources or {}, {
-        nls.builtins.code_actions.gomodifytags,
-        nls.builtins.code_actions.impl,
-        nls.builtins.formatting.goimports,
-        nls.builtins.formatting.gofumpt,
-      })
-    end,
-  },
-  {
-    "stevearc/conform.nvim",
-    optional = true,
-    opts = {
-      formatters_by_ft = {
-        go = { "goimports", "gofumpt" },
-      },
-    },
-  },
-  {
-    "mfussenegger/nvim-dap",
-    optional = true,
-    dependencies = {
-      {
-        "williamboman/mason.nvim",
-        opts = function(_, opts)
-          opts.ensure_installed = opts.ensure_installed or {}
-          vim.list_extend(opts.ensure_installed, { "delve" })
-        end,
-      },
-      {
-        "leoluz/nvim-dap-go",
-        config = true,
-      },
-    },
-  },
-  {
-    "nvim-neotest/neotest",
-    optional = true,
-    dependencies = {
-      "nvim-neotest/neotest-go",
-    },
-    opts = {
-      adapters = {
-        ["neotest-go"] = {},
-      },
-    },
-  },
+	{
+		"nvim-treesitter/nvim-treesitter",
+		opts = function(_, opts)
+			if type(opts.ensure_installed) == "table" then
+				vim.list_extend(opts.ensure_installed, {
+					"go",
+					"gomod",
+					"gowork",
+					"gosum",
+				})
+			end
+		end,
+	},
+	{
+		"neovim/nvim-lspconfig",
+		opts = {
+			servers = {
+				gopls = {
+					keys = {
+						-- Workaround for the lack of a DAP strategy in neotest-go: https://github.com/nvim-neotest/neotest-go/issues/12
+						{ "<leader>td", "<cmd>lua require('dap-go').debug_test()<CR>", desc = "Debug Nearest (Go)" },
+					},
+					settings = {
+						gopls = {
+							gofumpt = true,
+							codelenses = {
+								gc_details = false,
+								generate = true,
+								regenerate_cgo = true,
+								run_govulncheck = true,
+								test = true,
+								tidy = true,
+								upgrade_dependency = true,
+								vendor = true,
+							},
+							hints = {
+								assignVariableTypes = true,
+								compositeLiteralFields = true,
+								compositeLiteralTypes = true,
+								constantValues = true,
+								functionTypeParameters = true,
+								parameterNames = true,
+								rangeVariableTypes = true,
+							},
+							analyses = {
+								fieldalignment = true,
+								nilness = true,
+								unusedparams = true,
+								unusedwrite = true,
+								useany = true,
+							},
+							usePlaceholders = true,
+							completeUnimported = true,
+							staticcheck = true,
+							directoryFilters = { "-.git", "-.vscode", "-.idea", "-.vscode-test", "-node_modules" },
+							semanticTokens = true,
+						},
+					},
+				},
+			},
+			setup = {
+				gopls = function()
+					-- workaround for gopls not supporting semanticTokensProvider
+					-- https://github.com/golang/go/issues/54531#issuecomment-1464982242
+					Utils.lsp.on_attach(function(client, _)
+						if client.name == "gopls" then
+							if not client.server_capabilities.semanticTokensProvider then
+								local semantic = client.config.capabilities.textDocument.semanticTokens
+								client.server_capabilities.semanticTokensProvider = {
+									full = true,
+									legend = {
+										tokenTypes = semantic.tokenTypes,
+										tokenModifiers = semantic.tokenModifiers,
+									},
+									range = true,
+								}
+							end
+						end
+					end)
+				end,
+			},
+		},
+	},
+	{
+		"williamboman/mason.nvim",
+		opts = function(_, opts)
+			opts.ensure_installed = opts.ensure_installed or {}
+			vim.list_extend(opts.ensure_installed, { "goimports", "gofumpt" })
+		end,
+	},
+	{
+		"nvimtools/none-ls.nvim",
+		optional = true,
+		dependencies = {
+			{
+				"williamboman/mason.nvim",
+				opts = function(_, opts)
+					opts.ensure_installed = opts.ensure_installed or {}
+					vim.list_extend(opts.ensure_installed, { "gomodifytags", "impl" })
+				end,
+			},
+		},
+		opts = function(_, opts)
+			local nls = require("null-ls")
+			opts.sources = vim.list_extend(opts.sources or {}, {
+				nls.builtins.code_actions.gomodifytags,
+				nls.builtins.code_actions.impl,
+				nls.builtins.formatting.goimports,
+				nls.builtins.formatting.gofumpt,
+			})
+		end,
+	},
+	{
+		"stevearc/conform.nvim",
+		optional = true,
+		opts = {
+			formatters_by_ft = {
+				go = { "goimports", "gofumpt" },
+			},
+		},
+	},
+	{
+		"mfussenegger/nvim-dap",
+		optional = true,
+		dependencies = {
+			{
+				"williamboman/mason.nvim",
+				opts = function(_, opts)
+					opts.ensure_installed = opts.ensure_installed or {}
+					vim.list_extend(opts.ensure_installed, { "delve" })
+				end,
+			},
+			{
+				"leoluz/nvim-dap-go",
+				config = true,
+			},
+		},
+	},
+	{
+		"nvim-neotest/neotest",
+		optional = true,
+		dependencies = {
+			"nvim-neotest/neotest-go",
+		},
+		opts = {
+			adapters = {
+				["neotest-go"] = {},
+			},
+		},
+	},
 }

--- a/lua/universenvim/plugins/langs/json.lua
+++ b/lua/universenvim/plugins/langs/json.lua
@@ -1,36 +1,36 @@
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "json", "json5", "jsonc" })
-      end
-    end,
-  },
-  {
-    "b0o/SchemaStore.nvim",
-    lazy = true,
-    version = false,
-  },
-  {
-    "neovim/nvim-lspconfig",
-    opts = {
-      servers = {
-        jsonls = {
-          on_new_config = function(new_config)
-            new_config.settings.json.schemas = new_config.settings.json.schemas or {}
-            vim.list_extend(new_config.settings.json.schemas, require("schemastore").json.schemas())
-          end,
-          settings = {
-            json = {
-              format = {
-                enable = true,
-              },
-              validate = { enable = true },
-            },
-          },
-        },
-      },
-    },
-  },
+	{
+		"nvim-treesitter/nvim-treesitter",
+		opts = function(_, opts)
+			if type(opts.ensure_installed) == "table" then
+				vim.list_extend(opts.ensure_installed, { "json", "json5", "jsonc" })
+			end
+		end,
+	},
+	{
+		"b0o/SchemaStore.nvim",
+		lazy = true,
+		version = false,
+	},
+	{
+		"neovim/nvim-lspconfig",
+		opts = {
+			servers = {
+				jsonls = {
+					on_new_config = function(new_config)
+						new_config.settings.json.schemas = new_config.settings.json.schemas or {}
+						vim.list_extend(new_config.settings.json.schemas, require("schemastore").json.schemas())
+					end,
+					settings = {
+						json = {
+							format = {
+								enable = true,
+							},
+							validate = { enable = true },
+						},
+					},
+				},
+			},
+		},
+	},
 }

--- a/lua/universenvim/plugins/langs/markdown.lua
+++ b/lua/universenvim/plugins/langs/markdown.lua
@@ -1,86 +1,86 @@
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "markdown", "markdown_inline" })
-      end
-    end,
-  },
-  {
-    "williamboman/mason.nvim",
-    opts = function(_, opts)
-      opts.ensure_installed = opts.ensure_installed or {}
-      vim.list_extend(opts.ensure_installed, { "markdownlint", "marksman" })
-    end,
-  },
-  {
-    "nvimtools/none-ls.nvim",
-    optional = true,
-    opts = function(_, opts)
-      local nls = require("null-ls")
-      opts.sources = vim.list_extend(opts.sources or {}, {
-        nls.builtins.diagnostics.markdownlint,
-      })
-    end,
-  },
-  {
-    "mfussenegger/nvim-lint",
-    optional = true,
-    opts = {
-      linters_by_ft = {
-        markdown = { "markdownlint" },
-      },
-    },
-  },
-  {
-    "neovim/nvim-lspconfig",
-    opts = {
-      servers = {
-        marksman = {},
-      },
-    },
-  },
-  {
-    "iamcco/markdown-preview.nvim",
-    cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
-    build = function()
-      vim.fn["mkdp#util#install"]()
-    end,
-    keys = {
-      {
-        "<leader>cp",
-        ft = "markdown",
-        "<cmd>MarkdownPreviewToggle<cr>",
-        desc = "Markdown Preview",
-      },
-    },
-    config = function()
-      vim.cmd([[do FileType]])
-    end,
-  },
-  {
-    "lukas-reineke/headlines.nvim",
-    opts = function()
-      local opts = {}
-      for _, ft in ipairs({ "markdown", "norg", "rmd", "org" }) do
-        opts[ft] = {
-          headline_highlights = {},
-        }
-        for i = 1, 6 do
-          local hl = "Headline" .. i
-          vim.api.nvim_set_hl(0, hl, { link = "Headline", default = true })
-          table.insert(opts[ft].headline_highlights, hl)
-        end
-      end
-      return opts
-    end,
-    ft = { "markdown", "norg", "rmd", "org" },
-    config = function(_, opts)
-      vim.schedule(function()
-        require("headlines").setup(opts)
-        require("headlines").refresh()
-      end)
-    end,
-  },
+	{
+		"nvim-treesitter/nvim-treesitter",
+		opts = function(_, opts)
+			if type(opts.ensure_installed) == "table" then
+				vim.list_extend(opts.ensure_installed, { "markdown", "markdown_inline" })
+			end
+		end,
+	},
+	{
+		"williamboman/mason.nvim",
+		opts = function(_, opts)
+			opts.ensure_installed = opts.ensure_installed or {}
+			vim.list_extend(opts.ensure_installed, { "markdownlint", "marksman" })
+		end,
+	},
+	{
+		"nvimtools/none-ls.nvim",
+		optional = true,
+		opts = function(_, opts)
+			local nls = require("null-ls")
+			opts.sources = vim.list_extend(opts.sources or {}, {
+				nls.builtins.diagnostics.markdownlint,
+			})
+		end,
+	},
+	{
+		"mfussenegger/nvim-lint",
+		optional = true,
+		opts = {
+			linters_by_ft = {
+				markdown = { "markdownlint" },
+			},
+		},
+	},
+	{
+		"neovim/nvim-lspconfig",
+		opts = {
+			servers = {
+				marksman = {},
+			},
+		},
+	},
+	{
+		"iamcco/markdown-preview.nvim",
+		cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
+		build = function()
+			vim.fn["mkdp#util#install"]()
+		end,
+		keys = {
+			{
+				"<leader>cp",
+				ft = "markdown",
+				"<cmd>MarkdownPreviewToggle<cr>",
+				desc = "Markdown Preview",
+			},
+		},
+		config = function()
+			vim.cmd([[do FileType]])
+		end,
+	},
+	{
+		"lukas-reineke/headlines.nvim",
+		opts = function()
+			local opts = {}
+			for _, ft in ipairs({ "markdown", "norg", "rmd", "org" }) do
+				opts[ft] = {
+					headline_highlights = {},
+				}
+				for i = 1, 6 do
+					local hl = "Headline" .. i
+					vim.api.nvim_set_hl(0, hl, { link = "Headline", default = true })
+					table.insert(opts[ft].headline_highlights, hl)
+				end
+			end
+			return opts
+		end,
+		ft = { "markdown", "norg", "rmd", "org" },
+		config = function(_, opts)
+			vim.schedule(function()
+				require("headlines").setup(opts)
+				require("headlines").refresh()
+			end)
+		end,
+	},
 }

--- a/lua/universenvim/plugins/langs/tailwind.lua
+++ b/lua/universenvim/plugins/langs/tailwind.lua
@@ -1,40 +1,40 @@
 return {
-  {
-    "neovim/nvim-lspconfig",
-    opts = {
-      servers = {
-        tailwindcss = {
-          filetypes_exclude = { "markdown" },
-          filetypes_include = {},
-        },
-      },
-      setup = {
-        tailwindcss = function(_, opts)
-          local tw = require("lspconfig.server_configurations.tailwindcss")
-          opts.filetypes = opts.filetypes or {}
+	{
+		"neovim/nvim-lspconfig",
+		opts = {
+			servers = {
+				tailwindcss = {
+					filetypes_exclude = { "markdown" },
+					filetypes_include = {},
+				},
+			},
+			setup = {
+				tailwindcss = function(_, opts)
+					local tw = require("lspconfig.server_configurations.tailwindcss")
+					opts.filetypes = opts.filetypes or {}
 
-          vim.list_extend(opts.filetypes, tw.default_config.filetypes)
+					vim.list_extend(opts.filetypes, tw.default_config.filetypes)
 
-          opts.filetypes = vim.tbl_filter(function(ft)
-            return not vim.tbl_contains(opts.filetypes_exclude or {}, ft)
-          end, opts.filetypes)
+					opts.filetypes = vim.tbl_filter(function(ft)
+						return not vim.tbl_contains(opts.filetypes_exclude or {}, ft)
+					end, opts.filetypes)
 
-          vim.list_extend(opts.filetypes, opts.filetypes_include or {})
-        end,
-      },
-    },
-  },
-  {
-    "hrsh7th/nvim-cmp",
-    dependencies = {
-      { "roobert/tailwindcss-colorizer-cmp.nvim", config = true },
-    },
-    opts = function(_, opts)
-      local format_kinds_icons = opts.formatting.format
-      opts.formatting.format = function(entry, item)
-        format_kinds_icons(entry, item)
-        return require("tailwindcss-colorizer-cmp").formatter(entry, item)
-      end
-    end,
-  },
+					vim.list_extend(opts.filetypes, opts.filetypes_include or {})
+				end,
+			},
+		},
+	},
+	{
+		"hrsh7th/nvim-cmp",
+		dependencies = {
+			{ "roobert/tailwindcss-colorizer-cmp.nvim", config = true },
+		},
+		opts = function(_, opts)
+			local format_kinds_icons = opts.formatting.format
+			opts.formatting.format = function(entry, item)
+				format_kinds_icons(entry, item)
+				return require("tailwindcss-colorizer-cmp").formatter(entry, item)
+			end
+		end,
+	},
 }

--- a/lua/universenvim/plugins/langs/typescript.lua
+++ b/lua/universenvim/plugins/langs/typescript.lua
@@ -1,93 +1,93 @@
 local Utils = require("universenvim.utils")
 
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "typescript", "tsx" })
-      end
-    end,
-  },
-  {
-    "neovim/nvim-lspconfig",
-    dependencies = {
-      "jose-elias-alvarez/typescript.nvim",
-      init = function()
-        Utils.lsp.on_attach(function(_, buffer)
+	{
+		"nvim-treesitter/nvim-treesitter",
+		opts = function(_, opts)
+			if type(opts.ensure_installed) == "table" then
+				vim.list_extend(opts.ensure_installed, { "typescript", "tsx" })
+			end
+		end,
+	},
+	{
+		"neovim/nvim-lspconfig",
+		dependencies = {
+			"jose-elias-alvarez/typescript.nvim",
+			init = function()
+				Utils.lsp.on_attach(function(_, buffer)
           -- stylua: ignore
           vim.keymap.set( "n", "<leader>co", "TypescriptOrganizeImports", { buffer = buffer, desc = "Organize Imports" })
-          vim.keymap.set("n", "<leader>cR", "TypescriptRenameFile", { desc = "Rename File", buffer = buffer })
-        end)
-      end,
-    },
-    opts = {
-      servers = {
-        tsserver = {
-          settings = {
-            completions = {
-              completeFunctionCalls = true,
-            },
-          },
-        },
-      },
-      setup = {
-        tsserver = function(_, opts)
-          require("typescript").setup({ server = opts })
-          return true
-        end,
-      }
-    },
-  },
-  {
-    "mfussenegger/nvim-dap",
-    optional = true,
-    dependencies = {
-      {
-        "williamboman/mason.nvim",
-        opts = function(_, opts)
-          opts.ensure_installed = opts.ensure_installed or {}
-          table.insert(opts.ensure_installed, "js-debug-adapter")
-        end,
-      },
-    },
-    opts = function()
-      local dap = require("dap")
-      if not dap.adapters["pwa-node"] then
-        require("dap").adapters["pwa-node"] = {
-          type = "server",
-          host = "localhost",
-          port = "${port}",
-          executable = {
-            command = "node",
-            args = {
-              require("mason-registry").get_package("js-debug-adapter"):get_install_path()
-                .. "/js-debug/src/dapDebugServer.js",
-              "${port}",
-            },
-          },
-        }
-      end
-      for _, language in ipairs({ "typescript", "javascript", "typescriptreact", "javascriptreact" }) do
-        if not dap.configurations[language] then
-          dap.configurations[language] = {
-            {
-              type = "pwa-node",
-              request = "launch",
-              name = "Launch file",
-              program = "${file}",
-              cwd = "${workspaceFolder}",
-            },
-            {
-              type = "pwa-node",
-              request = "attach",
-              name = "Attach",
-              processId = require("dap.utils").pick_process,
-              cwd = "${workspaceFolder}",
-            },
-          }
-        end
-      end
-    end,
-  },
+					vim.keymap.set("n", "<leader>cR", "TypescriptRenameFile", { desc = "Rename File", buffer = buffer })
+				end)
+			end,
+		},
+		opts = {
+			servers = {
+				tsserver = {
+					settings = {
+						completions = {
+							completeFunctionCalls = true,
+						},
+					},
+				},
+			},
+			setup = {
+				tsserver = function(_, opts)
+					require("typescript").setup({ server = opts })
+					return true
+				end,
+			},
+		},
+	},
+	{
+		"mfussenegger/nvim-dap",
+		optional = true,
+		dependencies = {
+			{
+				"williamboman/mason.nvim",
+				opts = function(_, opts)
+					opts.ensure_installed = opts.ensure_installed or {}
+					table.insert(opts.ensure_installed, "js-debug-adapter")
+				end,
+			},
+		},
+		opts = function()
+			local dap = require("dap")
+			if not dap.adapters["pwa-node"] then
+				require("dap").adapters["pwa-node"] = {
+					type = "server",
+					host = "localhost",
+					port = "${port}",
+					executable = {
+						command = "node",
+						args = {
+							require("mason-registry").get_package("js-debug-adapter"):get_install_path()
+								.. "/js-debug/src/dapDebugServer.js",
+							"${port}",
+						},
+					},
+				}
+			end
+			for _, language in ipairs({ "typescript", "javascript", "typescriptreact", "javascriptreact" }) do
+				if not dap.configurations[language] then
+					dap.configurations[language] = {
+						{
+							type = "pwa-node",
+							request = "launch",
+							name = "Launch file",
+							program = "${file}",
+							cwd = "${workspaceFolder}",
+						},
+						{
+							type = "pwa-node",
+							request = "attach",
+							name = "Attach",
+							processId = require("dap.utils").pick_process,
+							cwd = "${workspaceFolder}",
+						},
+					}
+				end
+			end
+		end,
+	},
 }

--- a/lua/universenvim/plugins/langs/yaml.lua
+++ b/lua/universenvim/plugins/langs/yaml.lua
@@ -1,66 +1,66 @@
 local Utils = require("universenvim.utils")
 
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = function(_, opts)
-      if type(opts.ensure_installed) == "table" then
-        vim.list_extend(opts.ensure_installed, { "yaml" })
-      end
-    end,
-  },
-  {
-    "b0o/SchemaStore.nvim",
-    lazy = true,
-    version = false,
-  },
-  {
-    "neovim/nvim-lspconfig",
-    opts = {
-      servers = {
-        yamlls = {
-          capabilities = {
-            textDocument = {
-              foldingRange = {
-                dynamicRegistration = false,
-                lineFoldingOnly = true,
-              },
-            },
-          },
-          on_new_config = function(new_config)
-            new_config.settings.yaml.schemas = vim.tbl_deep_extend(
-              "force",
-              new_config.settings.yaml.schemas or {},
-              require("schemastore").yaml.schemas()
-            )
-          end,
-          settings = {
-            redhat = { telemetry = { enabled = false } },
-            yaml = {
-              keyOrdering = false,
-              format = {
-                enable = true,
-              },
-              validate = true,
-              schemaStore = {
-                enable = false,
-                url = "",
-              },
-            },
-          },
-        },
-      },
-      setup = {
-        yamlls = function()
-          if vim.fn.has("nvim-0.10") == 0 then
-            Utils.lsp.on_attach(function(client, _)
-              if client.name == "yamlls" then
-                client.server_capabilities.documentFormattingProvider = true
-              end
-            end)
-          end
-        end,
-      },
-    },
-  },
+	{
+		"nvim-treesitter/nvim-treesitter",
+		opts = function(_, opts)
+			if type(opts.ensure_installed) == "table" then
+				vim.list_extend(opts.ensure_installed, { "yaml" })
+			end
+		end,
+	},
+	{
+		"b0o/SchemaStore.nvim",
+		lazy = true,
+		version = false,
+	},
+	{
+		"neovim/nvim-lspconfig",
+		opts = {
+			servers = {
+				yamlls = {
+					capabilities = {
+						textDocument = {
+							foldingRange = {
+								dynamicRegistration = false,
+								lineFoldingOnly = true,
+							},
+						},
+					},
+					on_new_config = function(new_config)
+						new_config.settings.yaml.schemas = vim.tbl_deep_extend(
+							"force",
+							new_config.settings.yaml.schemas or {},
+							require("schemastore").yaml.schemas()
+						)
+					end,
+					settings = {
+						redhat = { telemetry = { enabled = false } },
+						yaml = {
+							keyOrdering = false,
+							format = {
+								enable = true,
+							},
+							validate = true,
+							schemaStore = {
+								enable = false,
+								url = "",
+							},
+						},
+					},
+				},
+			},
+			setup = {
+				yamlls = function()
+					if vim.fn.has("nvim-0.10") == 0 then
+						Utils.lsp.on_attach(function(client, _)
+							if client.name == "yamlls" then
+								client.server_capabilities.documentFormattingProvider = true
+							end
+						end)
+					end
+				end,
+			},
+		},
+	},
 }

--- a/lua/universenvim/plugins/ui/toggleterm.lua
+++ b/lua/universenvim/plugins/ui/toggleterm.lua
@@ -1,78 +1,77 @@
 return {
-  'akinsho/toggleterm.nvim', 
-  version = "*", 
-  config = function()
-    local status_ok, toggleterm = pcall(require, "toggleterm")
-    if not status_ok then
-      vim.notify("Toggleterm could not be loaded!", "error")
-      return
-    end
+	"akinsho/toggleterm.nvim",
+	version = "*",
+	config = function()
+		local status_ok, toggleterm = pcall(require, "toggleterm")
+		if not status_ok then
+			vim.notify("Toggleterm could not be loaded!", "error")
+			return
+		end
 
-    toggleterm.setup({
-      size = 20,
-      open_mapping = [[<c-\>]],
-      hide_numbers = true,
-      shade_filetypes = {},
-      shade_terminals = true,
-      shading_factor = 2,
-      start_in_insert = true,
-      insert_mappings = true,
-      persist_size = true,
-      direction = "float",
-      close_on_exit = true,
-      shell = vim.o.shell,
-      float_opts = {
-        border = "curved",
-        winblend = 0,
-        highlights = {
-          border = "Normal",
-          background = "Normal",
-        },
-      },
-    })
+		toggleterm.setup({
+			size = 20,
+			open_mapping = [[<c-\>]],
+			hide_numbers = true,
+			shade_filetypes = {},
+			shade_terminals = true,
+			shading_factor = 2,
+			start_in_insert = true,
+			insert_mappings = true,
+			persist_size = true,
+			direction = "float",
+			close_on_exit = true,
+			shell = vim.o.shell,
+			float_opts = {
+				border = "curved",
+				winblend = 0,
+				highlights = {
+					border = "Normal",
+					background = "Normal",
+				},
+			},
+		})
 
-    function _G.set_terminal_keymaps()
-      local opts = { noremap = true }
-      vim.api.nvim_buf_set_keymap(0, "t", "<esc>", [[<C-\><C-n>]], opts)
-      vim.api.nvim_buf_set_keymap(0, "t", "jk", [[<C-\><C-n>]], opts)
-      vim.api.nvim_buf_set_keymap(0, "t", "<C-h>", [[<C-\><C-n><C-W>h]], opts)
-      vim.api.nvim_buf_set_keymap(0, "t", "<C-j>", [[<C-\><C-n><C-W>j]], opts)
-      vim.api.nvim_buf_set_keymap(0, "t", "<C-k>", [[<C-\><C-n><C-W>k]], opts)
-      vim.api.nvim_buf_set_keymap(0, "t", "<C-l>", [[<C-\><C-n><C-W>l]], opts)
-    end
+		function _G.set_terminal_keymaps()
+			local opts = { noremap = true }
+			vim.api.nvim_buf_set_keymap(0, "t", "<esc>", [[<C-\><C-n>]], opts)
+			vim.api.nvim_buf_set_keymap(0, "t", "jk", [[<C-\><C-n>]], opts)
+			vim.api.nvim_buf_set_keymap(0, "t", "<C-h>", [[<C-\><C-n><C-W>h]], opts)
+			vim.api.nvim_buf_set_keymap(0, "t", "<C-j>", [[<C-\><C-n><C-W>j]], opts)
+			vim.api.nvim_buf_set_keymap(0, "t", "<C-k>", [[<C-\><C-n><C-W>k]], opts)
+			vim.api.nvim_buf_set_keymap(0, "t", "<C-l>", [[<C-\><C-n><C-W>l]], opts)
+		end
 
-    vim.cmd("autocmd! TermOpen term://* lua set_terminal_keymaps()")
+		vim.cmd("autocmd! TermOpen term://* lua set_terminal_keymaps()")
 
-    local Terminal = require("toggleterm.terminal").Terminal
-    local lazygit = Terminal:new({ cmd = "lazygit", hidden = true })
+		local Terminal = require("toggleterm.terminal").Terminal
+		local lazygit = Terminal:new({ cmd = "lazygit", hidden = true })
 
-    function _LAZYGIT_TOGGLE()
-      lazygit:toggle()
-    end
+		function _LAZYGIT_TOGGLE()
+			lazygit:toggle()
+		end
 
-    local node = Terminal:new({ cmd = "node", hidden = true })
+		local node = Terminal:new({ cmd = "node", hidden = true })
 
-    function _NODE_TOGGLE()
-      node:toggle()
-    end
+		function _NODE_TOGGLE()
+			node:toggle()
+		end
 
-    local ncdu = Terminal:new({ cmd = "ncdu", hidden = true })
+		local ncdu = Terminal:new({ cmd = "ncdu", hidden = true })
 
-    function _NCDU_TOGGLE()
-      ncdu:toggle()
-    end
+		function _NCDU_TOGGLE()
+			ncdu:toggle()
+		end
 
-    local htop = Terminal:new({ cmd = "htop", hidden = true })
+		local htop = Terminal:new({ cmd = "htop", hidden = true })
 
-    function _HTOP_TOGGLE()
-      htop:toggle()
-    end
+		function _HTOP_TOGGLE()
+			htop:toggle()
+		end
 
-    local python = Terminal:new({ cmd = "python", hidden = true })
+		local python = Terminal:new({ cmd = "python", hidden = true })
 
-    function _PYTHON_TOGGLE()
-      python:toggle()
-    end
-  end
+		function _PYTHON_TOGGLE()
+			python:toggle()
+		end
+	end,
 }
-


### PR DESCRIPTION
## Purpose

> In certain files (JSX, TSX, for example) LSP snippets are always on top suggesting html tags instead of correct suggestions based on context

## Solution Approach

> Added sorting function
> In addition, files got formatted