### PR TITLE
fix(octo): supress missing scope warning

### DIFF
--- a/lua/universenvim/plugins/coding/octo.lua
+++ b/lua/universenvim/plugins/coding/octo.lua
@@ -25,6 +25,9 @@ return {
 				left_bubble_delimiter = "", -- Bubble delimiter
 				github_hostname = "", -- GitHub Enterprise host
 				snippet_context_lines = 4, -- number or lines around commented lines
+				suppress_missing_scope = {
+					projects_v2 = true,
+				},
 				file_panel = {
 					size = 10, -- changed files panel rows
 					use_icons = true, -- use web-devicons in file panel (if false, nvim-web-devicons does not need to be installed)


### PR DESCRIPTION
## Purpose
> Remove octo warning


## Solution Approach
> Add supress_missing_scope configuration for `octo`
